### PR TITLE
added repositoryVulnerabilityAlert to notifications

### DIFF
--- a/src/Enum/NotificationType.php
+++ b/src/Enum/NotificationType.php
@@ -12,6 +12,7 @@ use MyCLabs\Enum\Enum;
 /**
  * @method static NotificationType ISSUE()
  * @method static NotificationType PULL_REQUEST()
+ * @method static NotificationType REPOSITORY_VULNERABILITY_ALERT()
  */
 class NotificationType extends Enum
 {

--- a/src/Enum/NotificationType.php
+++ b/src/Enum/NotificationType.php
@@ -20,4 +20,7 @@ class NotificationType extends Enum
 
     /** @var string */
     protected const PULL_REQUEST = 'PullRequest';
+
+    /** @var string  */
+    protected const REPOSITORY_VULNERABILITY_ALERT = 'RepositoryVulnerabilityAlert';
 }


### PR DESCRIPTION
If you have a vulnerability alert on one of your repository, you can't start the project. 

* Added a constant representing `RepositoryVulnerabilityAlert` in NotificationType.php to prevent this issue.