### PR TITLE
Add new Notification Type

### DIFF
--- a/src/Enum/NotificationType.php
+++ b/src/Enum/NotificationType.php
@@ -11,4 +11,5 @@ enum NotificationType: string
     case PULL_REQUEST = 'PullRequest';
     case RELEASE = 'Release';
     case REPOSITORY_VULNERABILITY_ALERT = 'RepositoryVulnerabilityAlert';
+    case REPOSITORY_DEPENDABOT_ALERTS_THREAD = 'RepositoryDependabotAlertsThread';
 }


### PR DESCRIPTION
Fix error :

> Uncaught Error: "RepositoryDependabotAlertsThread" is not a valid backing value for enum "App\Enum\NotificationType"